### PR TITLE
add mvn-assembly-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
-# Java 2 Rust 
+# Java 2 Rust
 
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://gitHub.com/cguz/)
-[![Eclipse](https://img.shields.io/badge/-Eclipse-blueviolet)](https://eclipse.org/) 
-[![Java](https://img.shields.io/badge/Java-ED8B00?&logo=java&logoColor=white)](https://java.org/) 
+[![Eclipse](https://img.shields.io/badge/-Eclipse-blueviolet)](https://eclipse.org/)
+[![Java](https://img.shields.io/badge/Java-ED8B00?&logo=java&logoColor=white)](https://java.org/)
 
 Author: Cesar Augusto Guzman Alvarez [@cguz](https://github.com/cguz/)
 
-
 ## Description
 
-This is a command line tool based on the version [web-application](https://github.com/aschoerk/converter-page). Thus, all the credits for the original author of the web-application.
+This is a command line tool based on the version [web-application](https://github.com/aschoerk/converter-page). Thus,
+all the credits for the original author of the web-application.
 
 The application is a small help when trying to port Java-Code to Rust.
 
 The author is a beginner in rust, so the generated code will sometimes be kind of "unrusty".
 
+## How to build it.
+
+Run `mvn package` and find your `java2rust.jar` in the project's `target` folder.
+
 ## How to use it.
 
-$ java -jar java-2-rust.jar [path_file.java | path_directory]
+$ java -jar java2rust.jar [path_file.java | path_directory]
 
 The converted files will be saved in the folder: "output"
 
@@ -25,30 +29,30 @@ The converted files will be saved in the folder: "output"
 
 - might be of use:
 
-  - conversion of declarations Java: "Type name = init" to "let name: Type = init"
-  - conversion of arrays type[] to vectors
-  - snake-case for camelcase-identifiers starting with lower case
-  - mapping of primitive types
-  - &self as first parameter in non static methods
-  - new type becomes type::new
-  - class becomes struct with its instance-variables
-  - class-methods can be found in extra block impl for { }
-  - decide about usage of mut
-  - conversion of integer-constants to float-constants where necessary
-  - conversion of Exceptions into Results
-  - static methods are called using ::
-  - @Test is converted to #[test]
-  - interfaces become traits
-  - Java methods with declared throws return Result<_,Rc<Exception>> used rust code can be found in directory rust.
+    - conversion of declarations Java: "Type name = init" to "let name: Type = init"
+    - conversion of arrays type[] to vectors
+    - snake-case for camelcase-identifiers starting with lower case
+    - mapping of primitive types
+    - &self as first parameter in non static methods
+    - new type becomes type::new
+    - class becomes struct with its instance-variables
+    - class-methods can be found in extra block impl for { }
+    - decide about usage of mut
+    - conversion of integer-constants to float-constants where necessary
+    - conversion of Exceptions into Results
+    - static methods are called using ::
+    - @Test is converted to #[test]
+    - interfaces become traits
+    - Java methods with declared throws return Result<_,Rc<Exception>> used rust code can be found in directory rust.
 
 - experimental
 
-  - conversion of throw to break loop with label
- 
+    - conversion of throw to break loop with label
+
 - very experimental certainly wrongly done:
 
-  - super-classes become instance-variables
+    - super-classes become instance-variables
 
 - what does not change
 
-  - javadoc-comments
+    - javadoc-comments

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>de.aschoerk.java-converter</groupId>
-  <artifactId>java-2-rust</artifactId>
-  <version>1.0-SNAPSHOT</version>
-  <name>java to rust</name>
-  <url>http://maven.apache.org</url>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>de.aschoerk.java-converter</groupId>
+    <artifactId>java-2-rust</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>java to rust</name>
+    <url>http://maven.apache.org</url>
     <properties>
         <!-- Infrastructure properties -->
         <compiler.source.version>1.8</compiler.source.version>
@@ -14,109 +14,160 @@
         <appengine.target.version>1.9.71</appengine.target.version>
         <appengine-maven-plugin-version>1.3.2</appengine-maven-plugin-version>
     </properties>
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-      <!-- Compile/runtime dependencies -->
-      <dependency>
-          <groupId>com.google.appengine</groupId>
-          <artifactId>appengine-api-1.0-sdk</artifactId>
-          <version>${appengine.target.version}</version>
-      </dependency>
-      <dependency>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-          <version>3.1</version>
-      </dependency>
-      <dependency>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-all</artifactId>
-          <version>1.3</version>
-          <scope>test</scope>
-      </dependency>
-    <dependency>
-      <groupId>com.github.javaparser</groupId>
-      <artifactId>javaparser-core</artifactId>
-      <version>2.5.1</version>
-    </dependency>
-      <dependency>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-          <version>3.3.2</version>
-      </dependency>
-      <dependency>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-math3</artifactId>
-          <version>3.6.1</version>
-      </dependency>
-      <dependency>
-          <groupId>freemarker</groupId>
-          <artifactId>freemarker</artifactId>
-          <version>2.3.9</version>
-      </dependency>
-      <dependency>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-          <version>4.12</version>
-          <scope>test</scope>
-      </dependency>
+    <dependencies>
 
-      <!-- Plexus -->
-      <dependency>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-container-default</artifactId>
-          <version>1.5.5</version>
-      </dependency>
-      <dependency>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-utils</artifactId>
-          <version>3.0.24</version>
-      </dependency>
-      <dependency>
-          <groupId>com.google.appengine</groupId>
-          <artifactId>appengine-testing</artifactId>
-          <version>${appengine.target.version}</version>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>com.google.appengine</groupId>
-          <artifactId>appengine-api-stubs</artifactId>
-          <version>${appengine.target.version}</version>
-          <scope>test</scope>
-      </dependency>
-  </dependencies>
-  <build>
-    <finalName>java-converter</finalName>
-      <plugins>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.5.1</version>
-              <configuration>
-                  <source>${compiler.source.version}</source>
-                  <target>${compiler.target.version}</target>
-                  <showWarnings>true</showWarnings>
-              </configuration>
-          </plugin>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <version>2.19.1</version>
-              <configuration>
-                  <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                  <argLine>-Xmx2096m</argLine>
-                  <forkCount>0.5C</forkCount>
-              </configuration>
-          </plugin>
-          <plugin>
-              <groupId>com.google.cloud.tools</groupId>
-              <artifactId>appengine-maven-plugin</artifactId>
-              <version>${appengine-maven-plugin-version}</version>
-          </plugin>
-      </plugins>
-  </build>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Compile/runtime dependencies -->
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-api-1.0-sdk</artifactId>
+            <version>${appengine.target.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+            <version>2.5.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+            <version>2.3.9</version>
+        </dependency>
+
+        <!-- Plexus -->
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>1.5.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.0.24</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-testing</artifactId>
+            <version>${appengine.target.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-api-stubs</artifactId>
+            <version>${appengine.target.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>java2rust</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>${compiler.source.version}</source>
+                    <target>${compiler.target.version}</target>
+                    <showWarnings>true</showWarnings>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <argLine>-Xmx2096m</argLine>
+                    <forkCount>0.5C</forkCount>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>appengine-maven-plugin</artifactId>
+                <version>${appengine-maven-plugin-version}</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>
+                                        de.aschoerk.java2rust.JavaConverter
+                                    </mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <configuration>
+                            <target>
+                                <!-- Remove the jar-with-dependencies suffix -->
+                                <move file="${project.build.directory}/${build.finalName}.jar"
+                                      tofile="${project.build.directory}/${build.finalName}-no-deps.jar"/>
+                                <move file="${project.build.directory}/${build.finalName}-jar-with-dependencies.jar"
+                                      tofile="${project.build.directory}/${build.finalName}.jar"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -155,10 +155,10 @@
                         <configuration>
                             <target>
                                 <!-- Remove the jar-with-dependencies suffix -->
-                                <move file="${project.build.directory}/${build.finalName}.jar"
-                                      tofile="${project.build.directory}/${build.finalName}-no-deps.jar"/>
-                                <move file="${project.build.directory}/${build.finalName}-jar-with-dependencies.jar"
-                                      tofile="${project.build.directory}/${build.finalName}.jar"/>
+                                <move file="${project.build.directory}/${project.build.finalName}.jar"
+                                      tofile="${project.build.directory}/${project.build.finalName}-no-deps.jar"/>
+                                <move file="${project.build.directory}/${project.build.finalName}-jar-with-dependencies.jar"
+                                      tofile="${project.build.directory}/${project.build.finalName}.jar"/>
                             </target>
                         </configuration>
                         <goals>


### PR DESCRIPTION
Fixes #6 

This PR:
1. allows to simply create a fully packaged jar through `mvn package`
2. reformats and cleans up POM
3. update build docs in `README.md` 
4. removes the java binary from the git repo 
5. changes the final artifact name to `java2rust.jar`