### PR TITLE
Bump to Java 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+# This workflow CI checks the Java project
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java2Rust CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: mvn verify (Java ${{ matrix.java }})
+    runs-on: ubuntu-latest
+
+    # We run parallel builds for the following Java versions
+    strategy:
+      matrix:
+        java: [ 11, 17 ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run mvn verify
+        run: mvn verify -B -ntp

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
     <url>http://maven.apache.org</url>
     <properties>
         <!-- Infrastructure properties -->
-        <compiler.source.version>1.8</compiler.source.version>
-        <compiler.target.version>1.8</compiler.target.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <appengine.app.version>1</appengine.app.version>
         <appengine.target.version>1.9.71</appengine.target.version>
         <appengine-maven-plugin-version>1.3.2</appengine-maven-plugin-version>
@@ -97,8 +97,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>${compiler.source.version}</source>
-                    <target>${compiler.target.version}</target>
                     <showWarnings>true</showWarnings>
                 </configuration>
             </plugin>
@@ -167,7 +165,6 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Bump the projects Java Version from 8 to 11.  

This also fixes issues with my IDE as parts of `JavaConverter` were already using Java 11 features.