### PR TITLE
fix: use default java file encoding

### DIFF
--- a/src/main/java/de/aschoerk/java2rust/JavaConverter.java
+++ b/src/main/java/de/aschoerk/java2rust/JavaConverter.java
@@ -68,7 +68,7 @@ public class JavaConverter {
 				output += camelToSnakeCase(outputSplit[0]) + EXTENSION;
 				
 				// read the content of the file
-				String text = Files.readString(path, StandardCharsets.ISO_8859_1);
+				String text = Files.readString(path);
 
 				System.out.println("- "+output);
 				


### PR DESCRIPTION

I noticed that UTF8 characters in source files are not preserved.

This PR fixes that.

Note, if a user wants a special encoding they can specify on the command line with `-Dfile.encoding=ISO-8859-1`